### PR TITLE
fix path in conf.py

### DIFF
--- a/ardent/transform.py
+++ b/ardent/transform.py
@@ -7,18 +7,16 @@ from .presets import get_registration_preset
 from .lddmm.transformer import Transformer
 from .lddmm.transformer import torch_register
 from .lddmm.transformer import torch_apply_transform
-
 # TODO: rename io as fileio to avoid conflict with standard library package io?
 # from .io import save as io_save
 from . import io
 from pathlib import Path
 import pickle
 
-
-class Transform:
+class Transform():
     """transform stores the deformation that is output by a registration 
     and provides methods for applying that transformation to various images."""
-
+    
     def __init__(self):
         """Initialize Transform object. If used without arguments, sets attributes 
         to None. 
@@ -31,10 +29,10 @@ class Transform:
         self.phiinvAinvs = None
         self.affine = None
 
-        self.transformer = None  # To be instantiated in the register method.
-
+        self.transformer = None # To be instantiated in the register method.
+    
     @staticmethod
-    def _handle_registration_parameters(preset: str, params: dict) -> dict:
+    def _handle_registration_parameters(preset:str, params:dict) -> dict:
         """
         Provide default parameters based on <preset>, superseded by the provided parameters <params>.
         
@@ -47,30 +45,18 @@ class Transform:
         """
 
         # Get default registration parameters based on <preset>.
-        preset_parameters = get_registration_preset(preset)  # Type: dict.
+        preset_parameters = get_registration_preset(preset) # Type: dict.
 
         # Supplement and supplant with <params> from the caller.
         preset_parameters.update(params)
 
         return preset_parameters
 
+
     # TODO: argument validation and resolution scalar to triple correction.
-    def register(
-        self,
-        template: np.ndarray,
-        target: np.ndarray,
-        template_resolution=[1, 1, 1],
-        target_resolution=[1, 1, 1],
-        preset=None,
-        sigmaR=None,
-        eV=None,
-        eL=None,
-        eT=None,
-        A=None,
-        v=None,
-        device=None,
-        **kwargs
-    ) -> None:
+    def register(self, template:np.ndarray, target:np.ndarray, template_resolution=[1,1,1], target_resolution=[1,1,1], 
+        preset=None, sigmaR=None, eV=None, eL=None, eT=None, 
+        A=None, v=None, device=None, **kwargs) -> None:
         """
         Perform a registration using transformer between template and target.
         Populates attributes for future calls to the apply_transform method.
@@ -108,35 +94,18 @@ class Transform:
 
         # Collect registration parameters from chosen caller.
         registration_parameters = dict(sigmaR=sigmaR, eV=eV, eL=eL, eT=eT, **kwargs)
-        registration_parameters = {
-            key: value
-            for key, value in registration_parameters.items()
-            if value is not None
-        }
+        registration_parameters = {key : value for key, value in registration_parameters.items() if value is not None}
         # Fill unspecified parameters with presets if applicable.
         if preset is not None:
-            registration_parameters = Transform._handle_registration_parameters(
-                preset, registration_parameters
-            )
+            registration_parameters = Transform._handle_registration_parameters(preset, registration_parameters)
 
         # Instantiate transformer as a new Transformer object.
         # self.affine and self.v will not be None if this Transform object was read with its load method or if its register method was already called.
-        transformer = Transformer(
-            I=template,
-            J=target,
-            Ires=template_resolution,
-            Jres=target_resolution,
-            transformer=self.transformer,
-            sigmaR=registration_parameters["sigmaR"],
-            A=A,
-            v=v,
-            device=device,
-        )
+        transformer = Transformer(I=template, J=target, Ires=template_resolution, Jres=target_resolution, 
+                                    transformer=self.transformer, sigmaR=registration_parameters['sigmaR'], A=A, v=v, device=device)
 
-        outdict = torch_register(
-            template, target, transformer, **registration_parameters
-        )
-        """outdict contains:
+        outdict = torch_register(template, target, transformer, **registration_parameters)
+        '''outdict contains:
             - phis
             - phiinvs
             - Aphis
@@ -144,20 +113,19 @@ class Transform:
             - A
 
             - transformer
-        """
+        '''
 
         # Populate attributes.
-        self.phis = outdict["phis"]
-        self.phiinvs = outdict["phiinvs"]
-        self.Aphis = outdict["Aphis"]
-        self.phiinvAinvs = outdict["phiinvAinvs"]
-        self.affine = outdict["A"]
+        self.phis = outdict['phis']
+        self.phiinvs = outdict['phiinvs']
+        self.Aphis = outdict['Aphis']
+        self.phiinvAinvs = outdict['phiinvAinvs']
+        self.affine = outdict['A']
 
-        self.transformer = outdict["transformer"]
+        self.transformer = outdict['transformer']
 
-    def apply_transform(
-        self, subject: np.ndarray, deform_to="template", save_path=None
-    ) -> np.ndarray:
+
+    def apply_transform(self, subject:np.ndarray, deform_to="template", save_path=None) -> np.ndarray:
         """
         Apply the transformation--computed by the last call to self.register--to subject, 
         deforming it into the space of <deform_to>.
@@ -173,15 +141,14 @@ class Transform:
             np.ndarray -- The result of deforming <subject> to match <deform_to>.
         """
 
-        deformed_subject = torch_apply_transform(
-            image=subject, deform_to=deform_to, transformer=self.transformer
-        )
-
+        deformed_subject = torch_apply_transform(image=subject, deform_to=deform_to, transformer=self.transformer)
+        
         if save_path is not None:
             io.save(deformed_subject, save_path)
 
         return deformed_subject
 
+    
     def save(self, file_path):
         """
         Save the entire instance of this Transform object (self) to file.
@@ -191,6 +158,7 @@ class Transform:
         """
 
         io.save_pickled(self, file_path)
+
 
     def load(self, file_path):
         """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
+sys.path.insert(0, os.path.abspath(".."))
 
 
 # -- Project information -----------------------------------------------------
@@ -52,7 +52,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 
 autosummary_generate = True
 
@@ -64,7 +64,6 @@ autodoc_member_order = "bysource"  # default is alphabetical
 
 # -- sphinx options ----------------------------------------------------------
 source_suffix = ".rst"
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 master_doc = "index"
 source_encoding = "utf-8"
 


### PR DESCRIPTION
Still lots of warnings on build -- @DevinCrowley you can fix

- note: needed to "install" ardent (`pip install -e .` from top level dir)
- autoformat of transform.py w/ `black` but only change was missing comma

i moved your exclude pattern up as it was defined twice